### PR TITLE
add code climate analysis platform link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Designed for both development and production time use.
 The best Java runtime for business-critical applications. 
 Zing® is ideal for systems that require predictable performance and pauseless operation.
 
+**[Code Climate/codeclimate](https://github.com/codeclimate/codeclimate)**
+Code Climate’s engineering process insights and automated code review for GitHub.
 
 ## Contributing 
 Your contributions are always welcome!


### PR DESCRIPTION
This PR adds a link to Code Climate, which is a command line interface for the Code Climate analysis platform. In code on Github It allows you to run Code Climate engines on your local machine inside of Docker containers.